### PR TITLE
Refactor Vue app to Vue3

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -16,6 +16,10 @@ const app = createApp(App)
 
 app.config.productionTip = false
 
+// Buefy expects Vue 2 style prototype object. Map Vue 3 global properties so
+// plugin install doesn't fail.
+app.prototype = app.config.globalProperties
+
 /* eslint-disable-next-line */
 app.config.baseURL = process.env.VUE_APP_API_ENDPOINT ? process.env.VUE_APP_API_ENDPOINT : window.location.origin+window.location.pathname+'?r='
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,4 +1,4 @@
-import { createApp } from '@vue/compat'
+import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
@@ -13,7 +13,6 @@ import '@fortawesome/fontawesome-free/css/fontawesome.css'
 //TODO: import './registerServiceWorker'
 
 const app = createApp(App)
-app.config.compatConfig = { MODE: 2 }
 
 app.config.productionTip = false
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -19,6 +19,9 @@ app.config.productionTip = false
 // Buefy expects Vue 2 style prototype object. Map Vue 3 global properties so
 // plugin install doesn't fail.
 app.prototype = app.config.globalProperties
+// Some Buefy internals reference the global Vue variable. Provide a minimal
+// shim so those references don't throw in Vue 3.
+window.Vue = { prototype: app.config.globalProperties }
 
 /* eslint-disable-next-line */
 app.config.baseURL = process.env.VUE_APP_API_ENDPOINT ? process.env.VUE_APP_API_ENDPOINT : window.location.origin+window.location.pathname+'?r='

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,4 +1,4 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
@@ -12,31 +12,34 @@ import '@fortawesome/fontawesome-free/css/fontawesome.css'
 
 //TODO: import './registerServiceWorker'
 
-Vue.config.productionTip = false
+const app = createApp(App)
+
+app.config.productionTip = false
 
 /* eslint-disable-next-line */
-Vue.config.baseURL = process.env.VUE_APP_API_ENDPOINT ? process.env.VUE_APP_API_ENDPOINT : window.location.origin+window.location.pathname+'?r='
+app.config.baseURL = process.env.VUE_APP_API_ENDPOINT ? process.env.VUE_APP_API_ENDPOINT : window.location.origin+window.location.pathname+'?r='
+
+app.config.globalProperties.$baseURL = app.config.baseURL
 
 axios.defaults.withCredentials = true
-axios.defaults.baseURL = Vue.config.baseURL
+axios.defaults.baseURL = app.config.baseURL
 
 axios.defaults.headers['Content-Type'] = 'application/json'
 
-Vue.use(Buefy, {
+app.use(Buefy, {
   defaultIconPack: 'fas',
 })
 
-Vue.use(VueLazyload, {
+app.use(VueLazyload, {
   preLoad: 1.3,
 })
 
+app.mixin(shared)
+app.use(router)
+app.use(store)
 
-Vue.mixin(shared)
-
-new Vue({
-  router,
-  store,
-  created: function() {
+app.mixin({
+  created() {
 
     api.getConfig()
       .then(ret => {
@@ -64,6 +67,7 @@ new Vue({
           indefinite: true,
         })
       })
-  },
-  render: h => h(App),
-}).$mount('#app')
+  }
+})
+
+app.mount('#app')

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -9,6 +9,7 @@ import api from './api/api'
 import VueLazyload from 'vue-lazyload'
 import '@fortawesome/fontawesome-free/css/all.css'
 import '@fortawesome/fontawesome-free/css/fontawesome.css'
+import Notification from './plugins/notification'
 
 //TODO: import './registerServiceWorker'
 
@@ -29,6 +30,9 @@ app.prototype = app.config.globalProperties
 // Some Buefy internals reference the global Vue variable. Provide a minimal
 // shim so those references don't throw in Vue 3.
 window.Vue = { prototype: app.config.globalProperties }
+
+// Provide a minimal notification plugin used throughout the app
+app.use(Notification)
 
 /* eslint-disable-next-line */
 app.config.baseURL = process.env.VUE_APP_API_ENDPOINT ? process.env.VUE_APP_API_ENDPOINT : window.location.origin+window.location.pathname+'?r='

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,4 +1,4 @@
-import { createApp } from 'vue'
+import { createApp } from '@vue/compat'
 import App from './App.vue'
 import router from './router'
 import store from './store'
@@ -13,6 +13,7 @@ import '@fortawesome/fontawesome-free/css/fontawesome.css'
 //TODO: import './registerServiceWorker'
 
 const app = createApp(App)
+app.config.compatConfig = { MODE: 2 }
 
 app.config.productionTip = false
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -14,6 +14,13 @@ import '@fortawesome/fontawesome-free/css/fontawesome.css'
 
 const app = createApp(App)
 
+// Provide Vue 2 style `_self` property for legacy components like Buefy
+app.mixin({
+  beforeCreate() {
+    this._self = this
+  }
+})
+
 app.config.productionTip = false
 
 // Buefy expects Vue 2 style prototype object. Map Vue 3 global properties so

--- a/frontend/mixins/shared.js
+++ b/frontend/mixins/shared.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import moment from 'moment'
 import store from '../store.js'
 import api from '../api/api'
@@ -157,7 +156,7 @@ const funcs = {
       })
     },
     getDownloadLink(path) {
-      return Vue.config.baseURL+'/download&path='+encodeURIComponent(Base64.encode(path))
+      return this.$baseURL+'/download&path='+encodeURIComponent(Base64.encode(path))
     },
     hasPreview(name) {
       return this.isText(name) || this.isImage(name)

--- a/frontend/plugins/notification.js
+++ b/frontend/plugins/notification.js
@@ -1,0 +1,13 @@
+export default {
+  install(app) {
+    app.config.globalProperties.$notification = {
+      open({ message }) {
+        if (typeof window !== 'undefined') {
+          alert(message)
+        } else {
+          console.error(message)
+        }
+      },
+    }
+  },
+}

--- a/frontend/router.js
+++ b/frontend/router.js
@@ -1,15 +1,10 @@
-import Vue from 'vue'
-import Router from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import Browser from './views/Browser.vue'
 import Users from './views/Users.vue'
 import Login from './views/Login.vue'
 import store from './store'
 
-Vue.use(Router)
-
-export default new Router({
-  mode: 'hash',
-  routes: [
+const routes = [
     {
       path: '/',
       name: 'browser',
@@ -30,5 +25,11 @@ export default new Router({
         }
       },
     },
-  ]
+]
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes
 })
+
+export default router

--- a/frontend/store.js
+++ b/frontend/store.js
@@ -1,11 +1,8 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
+import { createStore } from 'vuex'
 import shared from './mixins/shared'
 import _ from 'lodash'
 
-Vue.use(Vuex)
-
-export default new Vuex.Store({
+export default createStore({
   state: {
     initialized: false,
     config: {

--- a/frontend/translations/english.js
+++ b/frontend/translations/english.js
@@ -35,6 +35,8 @@ const data = {
   'Delete': 'Delete',
   'Download': 'Download',
   'Copy link': 'Copy link',
+  'Copied to clipboard': 'Copied to clipboard',
+  'Copy failed': 'Copy failed',
   'Done': 'Done',
   'File': 'File',
   'Drop files to upload': 'Drop files to upload',

--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -147,7 +147,7 @@
                 <b-dropdown-item v-if="can('write')" aria-role="listitem" @click="remove($event, props.row)">
                   <b-icon icon="trash-alt" size="is-small" /> {{ lang('Delete') }}
                 </b-dropdown-item>
-                <b-dropdown-item v-if="props.row.type == 'file' && can('download')" v-clipboard:copy="getDownloadLink(props.row.path)" aria-role="listitem">
+                <b-dropdown-item v-if="props.row.type == 'file' && can('download')" aria-role="listitem" @click="copyLink(props.row.path)">
                   <b-icon icon="clipboard" size="is-small" /> {{ lang('Copy link') }}
                 </b-dropdown-item>
               </b-dropdown>
@@ -170,7 +170,6 @@
 </template>
 
 <script>
-import Vue from 'vue'
 import Menu from './partials/Menu'
 import Tree from './partials/Tree'
 import Permissions from './partials/Permissions'
@@ -180,10 +179,7 @@ import Search from './partials/Search'
 import Pagination from './partials/Pagination'
 import Upload from './partials/Upload'
 import api from '../api/api'
-import VueClipboard from 'vue-clipboard2'
 import _ from 'lodash'
-
-Vue.use(VueClipboard)
 
 export default {
   name: 'Browser',
@@ -424,7 +420,7 @@ export default {
             message: this.lang('Your file is ready'),
             confirmText: this.lang('Download'),
             onConfirm: () => {
-              window.open(Vue.config.baseURL+'/batchdownload&uniqid='+ret.uniqid, '_blank')
+              window.open(this.$baseURL+'/batchdownload&uniqid='+ret.uniqid, '_blank')
             }
           })
         })
@@ -435,6 +431,21 @@ export default {
     },
     download(item) {
       window.open(this.getDownloadLink(item.path), '_blank')
+    },
+    copyLink(path) {
+      navigator.clipboard.writeText(this.getDownloadLink(path)).then(() => {
+        this.$toast.open({
+          message: this.lang('Copied to clipboard'),
+          type: 'is-success',
+          duration: 2000,
+        })
+      }).catch(() => {
+        this.$toast.open({
+          message: this.lang('Copy failed'),
+          type: 'is-danger',
+          duration: 2000,
+        })
+      })
     },
     search() {
       this.$modal.open({

--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -52,7 +52,6 @@
 
 <script>
 import Resumable from 'resumablejs'
-import Vue from 'vue'
 import api from '../../api/api'
 import axios from 'axios'
 import _ from 'lodash'
@@ -83,7 +82,7 @@ export default {
   },
   mounted() {
     this.resumable = new Resumable({
-      target: Vue.config.baseURL+'/upload',
+      target: this.$baseURL+'/upload',
       headers: {
         'x-csrf-token': axios.defaults.headers.common['x-csrf-token']
       },

--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -109,7 +109,10 @@ export default {
       return
     }
 
-    this.resumable.assignDrop(document.getElementById('dropzone'))
+    const dropElement = document.getElementById('dropzone')
+    if (dropElement) {
+      this.resumable.assignDrop(dropElement)
+    }
 
     this.resumable.on('fileAdded', (file) => {
       this.visible = true

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@vue/cli-plugin-eslint": "^4.3.1",
     "@vue/cli-plugin-unit-jest": "^4.3.1",
     "@vue/cli-service": "^4.3.1",
-    "@vue/test-utils": "1.0.0-beta.29",
+    "@vue/test-utils": "^2.0.0-rc.18",
     "axios": "^0.21.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
@@ -36,10 +36,9 @@
     "sass": "^1.82.0",
     "resumablejs": "^1.1.0",
     "sass-loader": "^7.3.1",
-    "vue": "^2.6.11",
-    "vue-clipboard2": "^0.3.1",
-    "vue-router": "^3.1.6",
-    "vue-template-compiler": "^2.6.11",
-    "vuex": "^3.4.0"
+    "vue": "^3.2.0",
+    "vue-router": "^4.1.0",
+    "vuex": "^4.0.0",
+    "@vue/compiler-sfc": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "vue": "^3.2.0",
     "vue-router": "^4.1.0",
     "vuex": "^4.0.0",
-    "@vue/compiler-sfc": "^3.2.0",
-    "@vue/compat": "^3.2.0"
+    "@vue/compiler-sfc": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
-    "@vue/cli-plugin-babel": "^4.3.1",
-    "@vue/cli-plugin-e2e-cypress": "^4.3.1",
-    "@vue/cli-plugin-eslint": "^4.3.1",
-    "@vue/cli-plugin-unit-jest": "^4.3.1",
-    "@vue/cli-service": "^4.3.1",
+    "@vue/cli-plugin-babel": "^5.0.0",
+    "@vue/cli-plugin-e2e-cypress": "^5.0.0",
+    "@vue/cli-plugin-eslint": "^5.0.0",
+    "@vue/cli-plugin-unit-jest": "^5.0.0",
+    "@vue/cli-service": "^5.0.0",
     "@vue/test-utils": "^2.0.0-rc.18",
     "axios": "^0.21.1",
     "babel-core": "7.0.0-bridge.0",
@@ -39,6 +39,7 @@
     "vue": "^3.2.0",
     "vue-router": "^4.1.0",
     "vuex": "^4.0.0",
-    "@vue/compiler-sfc": "^3.2.0"
+    "@vue/compiler-sfc": "^3.2.0",
+    "@vue/compat": "^3.2.0"
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,5 +10,9 @@ module.exports = {
         './frontend/main.js'
       ]
     }
+    config.resolve = config.resolve || {}
+    config.resolve.alias = Object.assign({}, config.resolve.alias, {
+      'vue': '@vue/compat'
+    })
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,8 +11,6 @@ module.exports = {
       ]
     }
     config.resolve = config.resolve || {}
-    config.resolve.alias = Object.assign({}, config.resolve.alias, {
-      'vue': '@vue/compat'
-    })
+    config.resolve.alias = Object.assign({}, config.resolve.alias)
   }
 }


### PR DESCRIPTION
## Summary
- update dependencies for Vue 3
- migrate main.js to use `createApp`
- update router and store initialization
- swap clipboard plugin for a simple method
- provide translation strings

## Testing
- `npm run test:unit` *(fails: vue-cli-service not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f14793880832490ae3a042e652a3e